### PR TITLE
Add Google Colab / nbviewer link for instant preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## 📲 Try It Online
+
+- [Open in Google Colab](https://colab.research.google.com/github/AnjiOnGit/ai-safety/blob/main/Safe_Unsafe_Examples.ipynb)
+- [View in nbviewer](https://nbviewer.org/github/AnjiOnGit/ai-safety/blob/main/Safe_Unsafe_Examples.ipynb)
+
+
+
+
 # AI Safety Incident Dashboard
 
 This is a simple and interactive **AI Safety Incident Dashboard** built with **React**, **TypeScript**, and **CSS**.


### PR DESCRIPTION
This PR adds an optional live preview link to view the notebook directly using Google Colab or nbviewer, making it easier for non-developers to access.